### PR TITLE
Support local models

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -11,7 +11,7 @@ function replaceModelRefs(restApiId, cfModel) {
         let match;
         if (
           (match = /{{model:\s*([\-\w]+)}}/.exec(obj[key])) ||
-          (match = /#\/definitions\/\s*([\-\w]+)}}/.exec(obj[key]))
+          (match = /#\/definitions\/\s*([\-\w]+)/.exec(obj[key]))
         ) {
           obj[key] = {
             'Fn::Join': [

--- a/src/models.js
+++ b/src/models.js
@@ -1,47 +1,50 @@
 'use strict';
 
 function replaceModelRefs(restApiId, cfModel) {
-    if (!cfModel.Properties || !cfModel.Properties.Schema || Object.keys(cfModel.Properties.Schema).length == 0) {
-      return cfModel;
-    }
-
-    function replaceRefs(obj) {
-        for (let key of Object.keys(obj)) {
-            if (key === '$ref') {
-                let match;
-                if (match = /{{model:\s*([\-\w]+)}}/.exec(obj[key])) {
-                    obj[key] = {
-                        'Fn::Join': [
-                            '/',
-                            [
-                                'https://apigateway.amazonaws.com/restapis',
-                                restApiId,
-                                'models',
-                                match[1]
-                            ]
-                        ]
-                    };
-                    if (!cfModel.DependsOn) {
-                        cfModel.DependsOn = new Set();
-                    }
-                    cfModel.DependsOn.add(match[1]+'Model');
-                }
-            } else if (typeof obj[key] === 'object' && obj[key] !== null) {
-                replaceRefs(obj[key]);
-            }
-        }
-    }
-
-    replaceRefs(cfModel.Properties.Schema);
-    if (cfModel.DependsOn) {
-        cfModel.DependsOn = Array.from(cfModel.DependsOn);
-    }
+  if (!cfModel.Properties || !cfModel.Properties.Schema || Object.keys(cfModel.Properties.Schema).length == 0) {
     return cfModel;
+  }
+
+  function replaceRefs(obj) {
+    for (let key of Object.keys(obj)) {
+      if (key === '$ref') {
+        let match;
+        if (
+          (match = /{{model:\s*([\-\w]+)}}/.exec(obj[key])) ||
+          (match = /#\/definitions\/\s*([\-\w]+)}}/.exec(obj[key]))
+        ) {
+          obj[key] = {
+            'Fn::Join': [
+              '/',
+              [
+                'https://apigateway.amazonaws.com/restapis',
+                restApiId,
+                'models',
+                match[1]
+              ]
+            ]
+          };
+          if (!cfModel.DependsOn) {
+            cfModel.DependsOn = new Set();
+          }
+          cfModel.DependsOn.add(match[1] + 'Model');
+        }
+      } else if (typeof obj[key] === 'object' && obj[key] !== null) {
+        replaceRefs(obj[key]);
+      }
+    }
+  }
+
+  replaceRefs(cfModel.Properties.Schema);
+  if (cfModel.DependsOn) {
+    cfModel.DependsOn = Array.from(cfModel.DependsOn);
+  }
+  return cfModel;
 }
 
 module.exports = {
   createCfModel: function createCfModel(restApiId) {
-    return function(model) {
+    return function (model) {
 
       let cfModel = {
         Type: 'AWS::ApiGateway::Model',
@@ -63,7 +66,7 @@ module.exports = {
 
   addModelDependencies: function addModelDependencies(models, resource) {
     Object.keys(models).forEach(contentType => {
-      if(this.cfTemplate.Resources[`${models[contentType]}Model`]) {
+      if (this.cfTemplate.Resources[`${models[contentType]}Model`]) {
         resource.DependsOn.add(`${models[contentType]}Model`);
       }
     });


### PR DESCRIPTION
This change is to support importing from existing swagger or jsonschema files that have dependent models under `definitions`; an example would be something like
```json
{
  "definitions": {
    "FileHeader": {
      "type": "object",
      "title": "A FileHeader describes a file part of a multipart request.",
      "properties": {
        "Filename": {
          "type": "string"
        },
        "Header": {
          "$ref": "#/definitions/MIMEHeader"
        },
        "Size": {
          "type": "integer",
          "format": "int64"
        }
      }
    },
    "MIMEHeader": {
      "description": "A MIMEHeader represents a MIME-style header mapping\nkeys to sets of values.",
      "type": "object",
      "additionalProperties": {
        "type": "array",
        "items": {
          "type": "string"
        }
      }
    }
  }
}
```